### PR TITLE
feat: query using debug element, and wrap debug element in TestElement

### DIFF
--- a/projects/ngx-speculoos/src/lib/component-tester.spec.ts
+++ b/projects/ngx-speculoos/src/lib/component-tester.spec.ts
@@ -98,6 +98,11 @@ describe('ComponentTester', () => {
       expect(tester.debugElement).toBe(tester.fixture.debugElement);
     });
 
+    it('should expose test element', () => {
+      expect(tester.testElement.debugElement).toBe(tester.fixture.debugElement);
+      expect(tester.testElement.nativeElement).toBe(tester.fixture.nativeElement);
+    });
+
     it('should expose component instance', () => {
       expect(tester.componentInstance).toBe(tester.fixture.componentInstance);
     });

--- a/projects/ngx-speculoos/src/lib/component-tester.ts
+++ b/projects/ngx-speculoos/src/lib/component-tester.ts
@@ -14,8 +14,15 @@ import { TestElementQuerier } from './test-element-querier';
  */
 export class ComponentTester<T> {
 
-  private querier: TestElementQuerier;
-  private _fixture: ComponentFixture<T>;
+  /**
+   * The test element of the component
+   */
+  readonly testElement: TestElement<any>;
+
+  /**
+   * The component fixture of the component
+   */
+  readonly fixture: ComponentFixture<T>;
 
   /**
    * Creates a component fixture of the given type with the TestBed and wraps it into a ComponentTester
@@ -31,12 +38,8 @@ export class ComponentTester<T> {
    * @param arg the type of the component to wrap, or a component fixture to wrap
    */
   constructor(arg: Type<T> | ComponentFixture<T>) {
-    this._fixture = (arg instanceof ComponentFixture) ? arg : TestBed.createComponent(arg);
-    this.querier = new TestElementQuerier(this, this._fixture.nativeElement);
-  }
-
-  get fixture(): ComponentFixture<T> {
-    return this._fixture;
+    this.fixture = (arg instanceof ComponentFixture) ? arg : TestBed.createComponent(arg);
+    this.testElement = TestElementQuerier.wrap(this.debugElement, this);
   }
 
   /**
@@ -69,7 +72,7 @@ export class ComponentTester<T> {
    * @returns the wrapped element, or null if no element matches the selector.
    */
   element(selector: string): TestElement<Element> | null {
-    return this.querier.element(selector);
+    return this.testElement.element(selector);
   }
 
   /**
@@ -81,7 +84,7 @@ export class ComponentTester<T> {
    * @returns the array of matched elements, empty if no element was matched
    */
   elements(selector: string): Array<TestElement<Element>> {
-    return this.querier.elements(selector);
+    return this.testElement.elements(selector);
   }
 
   /**
@@ -90,7 +93,7 @@ export class ComponentTester<T> {
    * @returns the wrapped input, or null if no element was matched
    */
   input(selector: string): TestInput | null  {
-    return this.querier.input(selector);
+    return this.testElement.input(selector);
   }
 
   /**
@@ -99,7 +102,7 @@ export class ComponentTester<T> {
    * @returns the wrapped select, or null if no element was matched
    */
   select(selector: string): TestSelect | null  {
-    return this.querier.select(selector);
+    return this.testElement.select(selector);
   }
 
   /**
@@ -109,7 +112,7 @@ export class ComponentTester<T> {
    * @throws {Error} if the matched element isn't actually a textarea
    */
   textarea(selector: string): TestTextArea | null {
-    return this.querier.textarea(selector);
+    return this.testElement.textarea(selector);
   }
 
   /**
@@ -118,7 +121,7 @@ export class ComponentTester<T> {
    * @returns the wrapped button, or null if no element was matched
    */
   button(selector: string): TestButton | null {
-    return this.querier.button(selector);
+    return this.testElement.button(selector);
   }
 
   /**

--- a/projects/ngx-speculoos/src/lib/test-button.ts
+++ b/projects/ngx-speculoos/src/lib/test-button.ts
@@ -1,12 +1,13 @@
 import { ComponentTester } from './component-tester';
 import { TestHtmlElement } from './test-html-element';
+import { DebugElement } from '@angular/core';
 
 /**
  * A wrapped button element, providing additional methods and attributes helping with writing tests
  */
 export class TestButton extends TestHtmlElement<HTMLButtonElement> {
-  constructor(tester: ComponentTester<any>, nativeElement: HTMLButtonElement) {
-    super(tester, nativeElement);
+  constructor(tester: ComponentTester<any>, debugElement: DebugElement) {
+    super(tester, debugElement);
   }
 
   /**

--- a/projects/ngx-speculoos/src/lib/test-element.spec.ts
+++ b/projects/ngx-speculoos/src/lib/test-element.spec.ts
@@ -17,7 +17,7 @@ import { TestInput } from './test-input';
         <a id="a"></a>
         <input id="input" />
         <button id="button">Test</button>
-        <select id="select"></select>
+        <select id="select" name="foo"></select>
         <textarea id="textarea"></textarea>
       </div>
     </div>
@@ -57,6 +57,14 @@ describe('TestElement', () => {
   it('should construct', () => {
     expect(tester.svg instanceof TestElement).toBe(true);
     expect(tester.svg instanceof TestHtmlElement).toBe(false);
+  });
+
+  it('should expose the native element', () => {
+    expect(tester.svg.nativeElement).toBe(tester.nativeElement.querySelector('#s1'));
+  });
+
+  it('should expose the debug element', () => {
+    expect(tester.svg.debugElement.nativeElement).toBe(tester.nativeElement.querySelector('#s1'));
   });
 
   it('should get the text content', () => {
@@ -154,6 +162,11 @@ describe('TestElement', () => {
     it('should only query children', () => {
       expect(parent.element('#s1')).toBeNull();
       expect(parent.element('#parent')).toBeNull();
+    });
+
+    it('should support complex queries', () => {
+      expect(parent.select('div:first-of-type select[name=foo]').nativeElement).toBe(tester.select('#select').nativeElement);
+      expect(parent.select('div:first-of-type select[name=bar]')).toBeNull();
     });
   });
 });

--- a/projects/ngx-speculoos/src/lib/test-element.ts
+++ b/projects/ngx-speculoos/src/lib/test-element.ts
@@ -4,6 +4,7 @@ import { TestSelect } from './test-select';
 import { TestTextArea } from './test-textarea';
 import { TestInput } from './test-input';
 import { TestElementQuerier } from './test-element-querier';
+import { DebugElement } from '@angular/core';
 
 /**
  * A wrapped DOM element, providing additional methods and attributes helping with writing tests
@@ -14,10 +15,14 @@ export class TestElement<E extends Element> {
 
   constructor(protected tester: ComponentTester<any>,
               /**
-               * the wrapped native element
+               * the wrapped debug element
                */
-              public nativeElement: E) {
-    this.querier = new TestElementQuerier(tester, nativeElement);
+              public readonly debugElement: DebugElement) {
+    this.querier = new TestElementQuerier(tester, debugElement);
+  }
+
+  get nativeElement(): E {
+    return this.debugElement.nativeElement;
   }
 
   /**

--- a/projects/ngx-speculoos/src/lib/test-html-element.ts
+++ b/projects/ngx-speculoos/src/lib/test-html-element.ts
@@ -1,12 +1,13 @@
 import { ComponentTester } from './component-tester';
 import { TestElement } from './test-element';
+import { DebugElement } from '@angular/core';
 
 /**
  * A wrapped DOM HTML element, providing additional methods and attributes helping with writing tests
  */
 export class TestHtmlElement<E extends HTMLElement> extends TestElement<E> {
-  constructor(tester: ComponentTester<any>, nativeElement: E) {
-    super(tester, nativeElement);
+  constructor(tester: ComponentTester<any>, debugElement: DebugElement) {
+    super(tester, debugElement);
   }
 
   /**

--- a/projects/ngx-speculoos/src/lib/test-input.ts
+++ b/projects/ngx-speculoos/src/lib/test-input.ts
@@ -1,12 +1,13 @@
 import { ComponentTester } from './component-tester';
 import { TestHtmlElement } from './test-html-element';
+import { DebugElement } from '@angular/core';
 
 /**
  * A wrapped DOM HTML input element, providing additional methods and attributes helping with writing tests
  */
 export class TestInput extends TestHtmlElement<HTMLInputElement> {
-  constructor(tester: ComponentTester<any>, nativeElement: HTMLInputElement) {
-    super(tester, nativeElement);
+  constructor(tester: ComponentTester<any>, debugElement: DebugElement) {
+    super(tester, debugElement);
   }
 
   /**

--- a/projects/ngx-speculoos/src/lib/test-select.ts
+++ b/projects/ngx-speculoos/src/lib/test-select.ts
@@ -1,12 +1,13 @@
 import { ComponentTester } from './component-tester';
 import { TestHtmlElement } from './test-html-element';
+import { DebugElement } from '@angular/core';
 
 /**
  * A wrapped DOM HTML select element, providing additional methods and attributes helping with writing tests
  */
 export class TestSelect extends TestHtmlElement<HTMLSelectElement> {
-  constructor(tester: ComponentTester<any>, nativeElement: HTMLSelectElement) {
-    super(tester, nativeElement);
+  constructor(tester: ComponentTester<any>, debugElement: DebugElement) {
+    super(tester, debugElement);
   }
 
   /**

--- a/projects/ngx-speculoos/src/lib/test-textarea.ts
+++ b/projects/ngx-speculoos/src/lib/test-textarea.ts
@@ -1,12 +1,13 @@
 import { ComponentTester } from './component-tester';
 import { TestHtmlElement } from './test-html-element';
+import { DebugElement } from '@angular/core';
 
 /**
  * A wrapped DOM HTML textarea element, providing additional methods and attributes helping with writing tests
  */
 export class TestTextArea extends TestHtmlElement<HTMLTextAreaElement> {
-  constructor(tester: ComponentTester<any>, nativeElement: HTMLTextAreaElement) {
-    super(tester, nativeElement);
+  constructor(tester: ComponentTester<any>, debugElement: DebugElement) {
+    super(tester, debugElement);
   }
 
   /**


### PR DESCRIPTION
A debugElement is more powerful than a nativeElement, since it allows querying by other means, and wraps a native element anyway.
So, this allows doing more complex queries, such as

```
   this.element('.section')
       .elements('.chapter')[1]
       .debugElement.query(By.directive(ImageComponent))
       .componentInstance
```

for example, to get the component instance of the first image of teh second chapter of the first section.

The tester itself now also has a wrapped element. This means that if a utility function needs a TestElement as argument, and we need to pass the element of the component under test itself to this function, we now can.