### PR TITLE
chore: adapt the changelog for the first release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,6 @@
 # Change Log
 
-All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
-
 <a name="0.1.0"></a>
 # 0.1.0 (2018-05-25)
 
-
-### Features
-
-* allow recursive selection ([c2d0df3](https://github.com/Ninja-Squad/ngx-speculoos/commit/c2d0df3))
-* improve constructor to make subclassing easier ([#3](https://github.com/Ninja-Squad/ngx-speculoos/issues/3)) ([d485ba5](https://github.com/Ninja-Squad/ngx-speculoos/commit/d485ba5))
-* query using debug element, and wrap debug element in TestElement ([43689c9](https://github.com/Ninja-Squad/ngx-speculoos/commit/43689c9))
+### Very first release :champagne:


### PR DESCRIPTION
Next ones will use the standard commit conventions, but it feels strange to just have 3 features mentioned here.