### PR TITLE
feat: custom matcher toContainText

### DIFF
--- a/projects/ngx-speculoos/src/jasmine-matchers.d.ts
+++ b/projects/ngx-speculoos/src/jasmine-matchers.d.ts
@@ -10,5 +10,10 @@ declare namespace jasmine {
      * Checks that the receiver is a TestInput or a TestTextArea and has the given value
      */
     toHaveValue(value: string): boolean;
+
+    /**
+     * Checks that the receiver is a TestElement wrapping a DOM element and contains the given textContent
+     */
+    toContainText(textContent: string): boolean;
   }
 }

--- a/projects/ngx-speculoos/src/lib/matchers.spec.ts
+++ b/projects/ngx-speculoos/src/lib/matchers.spec.ts
@@ -128,7 +128,6 @@ describe('Custom matchers', () => {
     it('should return true if wrong value and .not', () => {
       const result = matcher.negativeCompare(tester.name, 'baz');
       expect(result.pass).toBeTruthy();
-      expect(result.message).toBe(`Expected element to not have value 'baz', but had value 'Hello'`);
     });
 
     it('should return false if no element', () => {
@@ -153,6 +152,63 @@ describe('Custom matchers', () => {
       const result = matcher.negativeCompare('hello', 'baz');
       expect(result.pass).toBeFalsy();
       expect(result.message).toBe(`Expected to check value 'baz' on element, but element was neither a TestInput nor a TestTextArea`);
+    });
+
+  });
+
+  describe('toContainText', () => {
+    const matcher = speculoosMatchers.toContainText(undefined, undefined);
+
+    it('should check for a textContent', () => {
+      expect(tester.div).toContainText('Hello');
+      expect(tester.div).toContainText('He');
+      expect(tester.div).not.toContainText('baz');
+    });
+
+    it('should return false if wrong textContent', () => {
+      const result = matcher.compare(tester.div, 'baz');
+      expect(result.pass).toBeFalsy();
+      expect(result.message).toBe(`Expected element to contain textContent 'baz', but had textContent 'Hello'`);
+    });
+
+    it('should return true if wrong textContent and .not', () => {
+      const result = matcher.negativeCompare(tester.div, 'baz');
+      expect(result.pass).toBeTruthy();
+    });
+
+    it('should return false if no textContent', () => {
+      const result = matcher.compare(tester.name, 'baz');
+      expect(result.pass).toBeFalsy();
+      expect(result.message).toBe(`Expected element to contain textContent 'baz', but had no textContent`);
+    });
+
+    it('should return true if no textContent and .not', () => {
+      const result = matcher.negativeCompare(tester.name, 'baz');
+      expect(result.pass).toBeTruthy();
+    });
+
+    it('should return false if no element', () => {
+      const result = matcher.compare(null, 'baz');
+      expect(result.pass).toBeFalsy();
+      expect(result.message).toBe(`Expected to check textContent 'baz' on element, but element was falsy`);
+    });
+
+    it('should return false if no element and .not too', () => {
+      const result = matcher.negativeCompare(null, 'baz');
+      expect(result.pass).toBeFalsy();
+      expect(result.message).toBe(`Expected to check textContent 'baz' on element, but element was falsy`);
+    });
+
+    it('should return false if element of wrong type', () => {
+      const result = matcher.compare('hello', 'baz');
+      expect(result.pass).toBeFalsy();
+      expect(result.message).toBe(`Expected to check textContent 'baz' on element, but element was not a TestElement`);
+    });
+
+    it('should return false if element of wrong type and .not too', () => {
+      const result = matcher.negativeCompare('hello', 'baz');
+      expect(result.pass).toBeFalsy();
+      expect(result.message).toBe(`Expected to check textContent 'baz' on element, but element was not a TestElement`);
     });
 
   });

--- a/projects/ngx-speculoos/src/lib/matchers.ts
+++ b/projects/ngx-speculoos/src/lib/matchers.ts
@@ -60,6 +60,38 @@ const speculoosMatchers: jasmine.CustomMatcherFactories = {
         return assert(true, el, expected);
       }
     };
+  },
+
+  /**
+   * Checks that the receiver is a TestElement wrapping a DOM element and contains the given textContent
+   */
+  toContainText: (util: jasmine.MatchersUtil, customEqualityTesters: Array<jasmine.CustomEqualityTester>): jasmine.CustomMatcher => {
+    const assert = (isNegative: boolean, el: any, expected: string) => {
+      if (!el) {
+        return { pass: false, message: `Expected to check textContent '${expected}' on element, but element was falsy` };
+      }
+      if (!(el instanceof TestElement)) {
+        return { pass: false, message: `Expected to check textContent '${expected}' on element, but element was not a TestElement` };
+      }
+      const actual = el.textContent;
+      if (!actual) {
+        return {
+          pass: isNegative,
+          message: `Expected element to ${isNegative ? 'not ' : ''}contain textContent '${expected}', but had no textContent`
+        };
+      }
+      const pass = actual.indexOf(expected) !== -1;
+      const message = `Expected element to ${isNegative ? 'not ' : ''}contain textContent '${expected}', but had textContent '${actual}'`;
+      return { pass: isNegative ? !pass : pass, message };
+    };
+    return {
+      compare: (el: any, expected: string): jasmine.CustomMatcherResult => {
+        return assert(false, el, expected);
+      },
+      negativeCompare: (el: any, expected: string): jasmine.CustomMatcherResult => {
+        return assert(true, el, expected);
+      }
+    };
   }
 };
 


### PR DESCRIPTION
Usage: `expect(page.title).toContainText('Welcome');`

On top of #1