### PR TITLE
chore(deps): activate renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["config:base", "schedule:earlyMondays"],
+  "packageRules": [
+    {
+      "packagePatterns": ["^@angular"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
This extends the default config,
but activate renovate only once per week,
on Mondays.

It also deactivate the update of the `@angular` packages