### PR TITLE
refactor(matchers): remove custom jasmine types

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@angular/platform-browser-dynamic": "^6.0.2",
     "@angular/router": "^6.0.2",
     "@compodoc/compodoc": "^1.1.3",
-    "@types/jasmine": "~2.8.6",
+    "@types/jasmine": "~2.8.8",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "~8.9.4",
     "codecov": "3.0.2",

--- a/projects/ngx-speculoos/src/custom-jasmine-types.d.ts
+++ b/projects/ngx-speculoos/src/custom-jasmine-types.d.ts
@@ -1,8 +1,0 @@
-declare namespace jasmine {
-  // the official CustomMatcher interface doesn't have negativeCompare
-  // can be removed once PR https://github.com/DefinitelyTyped/DefinitelyTyped/pull/26051 is released
-  interface CustomMatcher {
-    negativeCompare?<T>(actual: T, expected: T, ...args: any[]): CustomMatcherResult;
-    negativeCompare?(actual: any, ...expected: any[]): CustomMatcherResult;
-  }
-}

--- a/projects/ngx-speculoos/src/lib/matchers.ts
+++ b/projects/ngx-speculoos/src/lib/matchers.ts
@@ -1,5 +1,3 @@
-/// <reference path="../custom-jasmine-types.d.ts" />
-
 import { TestTextArea } from './test-textarea';
 import { TestInput } from './test-input';
 import { TestElement } from './test-element';

--- a/yarn.lock
+++ b/yarn.lock
@@ -258,9 +258,13 @@
   dependencies:
     "@types/node" "*"
 
-"@types/jasmine@*", "@types/jasmine@~2.8.6":
+"@types/jasmine@*":
   version "2.8.7"
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.8.7.tgz#3fe583928ae0a22cdd34cedf930eeffeda2602fd"
+
+"@types/jasmine@~2.8.8":
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.8.8.tgz#bf53a7d193ea8b03867a38bfdb4fbb0e0bf066c9"
 
 "@types/jasminewd2@~2.0.3":
   version "2.0.3"


### PR DESCRIPTION
`@types/jasmine` is out in 2.8.8 with my PR merged
See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/26051