### PR TITLE
chore(renovate): automerge minor bump if PR is green

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,13 @@
   "extends": ["config:base", "schedule:earlyMondays", ":semanticCommitTypeAll(chore)"],
   "packageRules": [
     {
-      "packagePatterns": ["^@angular"],
+      "packagePatterns": ["^@angular", "^typescript"],
       "enabled": false
     }
-  ]
+  ],
+  "automerge": true,
+  "automergeType": "branch",
+  "major": {
+    "automerge": false
+  }
 }


### PR DESCRIPTION
But don't if it is a major bump.
Ignore TypeScript update (we'll handle manually with Angular updates).
Also use the "branch" merge, to avoid a merge commit.