### PR TITLE
chore(renovate): loosening of renovate schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:base", "schedule:earlyMondays", ":semanticCommitTypeAll(chore)"],
+  "extends": ["config:base", ":semanticCommitTypeAll(chore)"],
   "packageRules": [
     {
       "packagePatterns": ["^@angular", "^typescript"],


### PR DESCRIPTION
Looks like the eraly monday schedule is not enough time for renovate to trigger the PRs (now that it waits for the build to be green).
Let's try with no schedule at all and see how it goes.