### PR TITLE
feat: strict and better typings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
       - run: yarn lint
       - run: yarn test
       - run: yarn build
+      - run: yarn tsd
       - run: yarn demotest
       - run: yarn demobuild
       - run: yarn doc

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "ng lint",
     "release": "cd projects/ngx-speculoos && standard-version --infile ../../CHANGELOG.md",
     "doc": "node scripts/prepare-doc.js && cd projects/ngx-speculoos && compodoc",
-    "codecov": "codecov"
+    "codecov": "codecov",
+    "tsd": "tsd projects/tsd-test"
   },
   "private": true,
   "dependencies": {
@@ -47,7 +48,16 @@
     "ng-packagr": "10.0.0",
     "standard-version": "8.0.0",
     "ts-node": "8.10.2",
+    "tsd": "0.11.0",
     "tslint": "6.1.2",
     "typescript": "3.9.5"
+  },
+  "tsd": {
+    "directory": "projects/tsd-test",
+    "compilerOptions": {
+      "lib": [
+        "dom"
+      ]
+    }
   }
 }

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -7,7 +7,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
   styleUrls: ['./app.component.css']
 })
 export class AppComponent implements OnInit {
-  form: FormGroup;
+  form!: FormGroup;
   greeting = '';
 
   constructor(private fb: FormBuilder) { }

--- a/projects/demo/src/test.ts
+++ b/projects/demo/src/test.ts
@@ -7,13 +7,19 @@ import {
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
 
-declare const require: any;
+declare const require: {
+  context(
+    path: string,
+    deep?: boolean,
+    filter?: RegExp
+  ): {
+    keys(): Array<string>;
+    <T>(id: string): T;
+  };
+};
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
-);
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.

--- a/projects/demo/tsconfig.spec.json
+++ b/projects/demo/tsconfig.spec.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../out-tsc/spec",
+    "strictNullChecks": false,
     "types": [
       "jasmine",
       "node"

--- a/projects/ngx-speculoos/src/lib/component-tester.ts
+++ b/projects/ngx-speculoos/src/lib/component-tester.ts
@@ -6,28 +6,29 @@ import { TestInput } from './test-input';
 import { TestSelect } from './test-select';
 import { TestButton } from './test-button';
 import { TestElementQuerier } from './test-element-querier';
+import { TestHtmlElement } from './test-html-element';
 
 /**
  * The main entry point of the API. It wraps an Angular ComponentFixture<T>, and gives access to its
  * most used properties and methods. It also allows getting elements wrapped in TestElement (and its subclasses)
- * @param <T> the type of the component to test
+ * @param <C> the type of the component to test
  */
-export class ComponentTester<T> {
+export class ComponentTester<C> {
 
   /**
    * The test element of the component
    */
-  readonly testElement: TestElement<any>;
+  readonly testElement: TestElement<HTMLElement>;
 
   /**
    * The component fixture of the component
    */
-  readonly fixture: ComponentFixture<T>;
+  readonly fixture: ComponentFixture<C>;
 
   /**
    * Creates a component fixture of the given type with the TestBed and wraps it into a ComponentTester
    */
-  static create<T>(componentType: Type<T>) {
+  static create<C>(componentType: Type<C>) {
     const fixture = TestBed.createComponent(componentType);
     return new ComponentTester(fixture);
   }
@@ -43,9 +44,9 @@ export class ComponentTester<T> {
    *
    * @param arg the type of the component to wrap, or a component fixture to wrap
    */
-  constructor(arg: Type<T> | ComponentFixture<T>) {
+  constructor(arg: Type<C> | ComponentFixture<C>) {
     this.fixture = (arg instanceof ComponentFixture) ? arg : TestBed.createComponent(arg);
-    this.testElement = TestElementQuerier.wrap(this.debugElement, this);
+    this.testElement = TestElementQuerier.wrap(this.debugElement, this) as TestElement<HTMLElement>;
   }
 
   /**
@@ -58,7 +59,7 @@ export class ComponentTester<T> {
   /**
    * Gets the instance of the tested component from the wrapped fixture
    */
-  get componentInstance(): T {
+  get componentInstance(): C {
     return this.fixture.componentInstance;
   }
 
@@ -72,24 +73,224 @@ export class ComponentTester<T> {
   /**
    * Gets the first element matching the given CSS selector and wraps it into a TestElement. The actual type
    * of the returned value is the TestElement subclass matching the type of the found element. So, if the
-   * matched element is an input for example, the method will return a TestInput. You can thus use
-   * `tester.element('#some-input') as TestInput`.
+   * matched element is an input for example, the method will return a TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElement: TestHtmlElement&lt;HTMLDivElement> | null = tester.element('div');
+   * </code>
    * @param selector a CSS selector
    * @returns the wrapped element, or null if no element matches the selector.
    */
-  element(selector: string): TestElement<Element> | null {
+  element<K extends keyof HTMLElementTagNameMap>(selector: K): TestHtmlElement<HTMLElementTagNameMap[K]> | null;
+  /**
+   * Gets the first element matching the given CSS selector and wraps it into a TestElement. The actual type
+   * of the returned value is the TestElement subclass matching the type of the found element. So, if the
+   * matched element is an input for example, the method will return a TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElement: TestElement&lt;SVGLineElement> | null = tester.element('line');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the wrapped element, or null if no element matches the selector.
+   */
+  element<K extends keyof SVGElementTagNameMap>(selector: K): TestElement<SVGElementTagNameMap[K]> | null;
+  /**
+   * Gets the first element matching the given CSS selector and wraps it into a TestElement. The actual type
+   * of the returned value is the TestElement subclass matching the type of the found element. So, if the
+   * matched element is an input for example, the method will return a TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElement: TestElement | null = tester.element('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the wrapped element, or null if no element matches the selector.
+   */
+  element(selector: string): TestElement | null;
+  /**
+   * Gets the first element matching the given CSS selector and wraps it into a TestElement. The actual type
+   * of the returned value is the TestElement subclass matching the type of the found element. So, if the
+   * matched element is an input for example, the method will return a TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElement: TestInput | null = tester.element&lt;HTMLInputElement>('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the wrapped element, or null if no element matches the selector.
+   */
+  element<T extends HTMLInputElement>(selector: string): TestInput | null;
+  /**
+   * Gets the first element matching the given CSS selector and wraps it into a TestElement. The actual type
+   * of the returned value is the TestElement subclass matching the type of the found element. So, if the
+   * matched element is an input for example, the method will return a TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElement: TestTextArea | null = tester.element&lt;HTMLTextAreaElement>('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the wrapped element, or null if no element matches the selector.
+   */
+  element<T extends HTMLTextAreaElement>(selector: string): TestTextArea | null;
+  /**
+   * Gets the first element matching the given CSS selector and wraps it into a TestElement. The actual type
+   * of the returned value is the TestElement subclass matching the type of the found element. So, if the
+   * matched element is an input for example, the method will return a TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElement: TestSelect | null = tester.element&lt;HTMLSelectElement>('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the wrapped element, or null if no element matches the selector.
+   */
+  element<T extends HTMLSelectElement>(selector: string): TestSelect | null;
+  /**
+   * Gets the first element matching the given CSS selector and wraps it into a TestElement. The actual type
+   * of the returned value is the TestElement subclass matching the type of the found element. So, if the
+   * matched element is an input for example, the method will return a TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElement: TestButton | null = tester.element&lt;HTMLButtonElement>('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the wrapped element, or null if no element matches the selector.
+   */
+  element<T extends HTMLButtonElement>(selector: string): TestButton | null;
+  /**
+   * Gets the first element matching the given CSS selector and wraps it into a TestElement. The actual type
+   * of the returned value is the TestElement subclass matching the type of the found element. So, if the
+   * matched element is an input for example, the method will return a TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElement: TestHtmlElement&lt;HTMLDivElement> | null = tester.element&lt;HTMLDivElement>('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the wrapped element, or null if no element matches the selector.
+   */
+  element<T extends HTMLElement>(selector: string): TestHtmlElement<T> | null;
+  /**
+   * Gets the first element matching the given CSS selector and wraps it into a TestElement. The actual type
+   * of the returned value is the TestElement subclass matching the type of the found element. So, if the
+   * matched element is an input for example, the method will return a TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElement: TestElement&lt;SVGLineElement> | null = tester.element&lt;SVGLineElement>('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the wrapped element, or null if no element matches the selector.
+   */
+  element<T extends Element>(selector: string): TestElement<T> | null;
+  element(selector: string): TestElement | null {
     return this.testElement.element(selector);
   }
 
   /**
    * Gets all the elements matching the given CSS selector and wraps them into a TestElement. The actual type
    * of the returned elements is the TestElement subclass matching the type of the found element. So, if the
-   * matched elements are inputs for example, the method will return an array of TestInput. You can thus use
-   * `tester.elements('input') as Array<TestInput>`.
+   * matched elements are inputs for example, the method will return an array of TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElements: Array&lt;TestHtmlElement&lt;HTMLDivElement>> = tester.elements('div');
+   * </code>
    * @param selector a CSS selector
    * @returns the array of matched elements, empty if no element was matched
    */
-  elements(selector: string): Array<TestElement<Element>> {
+  elements<K extends keyof HTMLElementTagNameMap>(selector: K): Array<TestHtmlElement<HTMLElementTagNameMap[K]>>;
+  /**
+   * Gets all the elements matching the given CSS selector and wraps them into a TestElement. The actual type
+   * of the returned elements is the TestElement subclass matching the type of the found element. So, if the
+   * matched elements are inputs for example, the method will return an array of TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElements: Array&lt;TestElement&lt;SVGLineElement>> = tester.elements('line');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the array of matched elements, empty if no element was matched
+   */
+  elements<K extends keyof SVGElementTagNameMap>(selector: K): Array<TestElement<SVGElementTagNameMap[K]>>;
+  /**
+   * Gets all the elements matching the given CSS selector and wraps them into a TestElement. The actual type
+   * of the returned elements is the TestElement subclass matching the type of the found element. So, if the
+   * matched elements are inputs for example, the method will return an array of TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElements: Array&lt;TestElement> = tester.elements('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the array of matched elements, empty if no element was matched
+   */
+  elements(selector: string): Array<TestElement>;
+  /**
+   * Gets all the elements matching the given CSS selector and wraps them into a TestElement. The actual type
+   * of the returned elements is the TestElement subclass matching the type of the found element. So, if the
+   * matched elements are inputs for example, the method will return an array of TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElements: Array&lt;TestInput> = tester.elements&lt;HTMLInputElement>('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the array of matched elements, empty if no element was matched
+   */
+  elements<T extends HTMLInputElement>(selector: string): Array<TestInput>;
+  /**
+   * Gets all the elements matching the given CSS selector and wraps them into a TestElement. The actual type
+   * of the returned elements is the TestElement subclass matching the type of the found element. So, if the
+   * matched elements are inputs for example, the method will return an array of TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElements: Array&lt;TestTextArea> = tester.elements&lt;HTMLTextAreaElement>('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the array of matched elements, empty if no element was matched
+   */
+  elements<T extends HTMLTextAreaElement>(selector: string): Array<TestTextArea>;
+  /**
+   * Gets all the elements matching the given CSS selector and wraps them into a TestElement. The actual type
+   * of the returned elements is the TestElement subclass matching the type of the found element. So, if the
+   * matched elements are inputs for example, the method will return an array of TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElements: Array&lt;TestButton> = tester.elements&lt;HTMLButtonElement>('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the array of matched elements, empty if no element was matched
+   */
+  elements<T extends HTMLButtonElement>(selector: string): Array<TestButton>;
+  /**
+   * Gets all the elements matching the given CSS selector and wraps them into a TestElement. The actual type
+   * of the returned elements is the TestElement subclass matching the type of the found element. So, if the
+   * matched elements are inputs for example, the method will return an array of TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElements: Array&lt;TestSelect> = tester.elements<HTMLSelectElement>('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the array of matched elements, empty if no element was matched
+   */
+  elements<T extends HTMLSelectElement>(selector: string): Array<TestSelect>;
+  /**
+   * Gets all the elements matching the given CSS selector and wraps them into a TestElement. The actual type
+   * of the returned elements is the TestElement subclass matching the type of the found element. So, if the
+   * matched elements are inputs for example, the method will return an array of TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElements: Array&lt;TestHtmlElement&lt;HTMLDivElement>> = tester.elements&lt;HTMLDivElement>('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the array of matched elements, empty if no element was matched
+   */
+  elements<T extends HTMLElement>(selector: string): Array<TestHtmlElement<T>>;
+  /**
+   * Gets all the elements matching the given CSS selector and wraps them into a TestElement. The actual type
+   * of the returned elements is the TestElement subclass matching the type of the found element. So, if the
+   * matched elements are inputs for example, the method will return an array of TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElements: Array&lt;TestElement&lt;SVGLineElement>> = tester.elements&lt;SVGLineElement>('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the array of matched elements, empty if no element was matched
+   */
+  elements<T extends Element>(selector: string): Array<TestElement<T>>;
+  elements(selector: string): Array<TestElement> {
     return this.testElement.elements(selector);
   }
 

--- a/projects/ngx-speculoos/src/lib/matchers.ts
+++ b/projects/ngx-speculoos/src/lib/matchers.ts
@@ -8,7 +8,7 @@ const speculoosMatchers: jasmine.CustomMatcherFactories = {
    * Checks that the receiver is a TestElement wrapping a DOM element and as the given CSS class
    */
   toHaveClass: (util: jasmine.MatchersUtil, customEqualityTesters: ReadonlyArray<jasmine.CustomEqualityTester>): jasmine.CustomMatcher => {
-    const assert = (isNegative: boolean, el: any, expected: string) => {
+    const assert = (isNegative: boolean, el: unknown, expected: string) => {
       if (!el) {
         return { pass: false, message: `Expected to check class '${expected}' on element, but element was falsy` };
       }
@@ -22,10 +22,10 @@ const speculoosMatchers: jasmine.CustomMatcherFactories = {
       return { pass: isNegative ? !pass : pass, message };
     };
     return {
-      compare: (el: any, expected: string): jasmine.CustomMatcherResult => {
+      compare: (el: unknown, expected: string): jasmine.CustomMatcherResult => {
         return assert(false, el, expected);
       },
-      negativeCompare: (el: any, expected: string): jasmine.CustomMatcherResult => {
+      negativeCompare: (el: unknown, expected: string): jasmine.CustomMatcherResult => {
         return assert(true, el, expected);
       }
     };
@@ -35,7 +35,7 @@ const speculoosMatchers: jasmine.CustomMatcherFactories = {
    * Checks that the receiver is a TestInput or a TestTextArea and has the given value
    */
   toHaveValue: (util: jasmine.MatchersUtil, customEqualityTesters: ReadonlyArray<jasmine.CustomEqualityTester>): jasmine.CustomMatcher => {
-    const assert = (isNegative: boolean, el: any, expected: string) => {
+    const assert = (isNegative: boolean, el: unknown, expected: string) => {
       if (!el) {
         return { pass: false, message: `Expected to check value '${expected}' on element, but element was falsy` };
       }
@@ -51,10 +51,10 @@ const speculoosMatchers: jasmine.CustomMatcherFactories = {
       return { pass: isNegative ? !pass : pass, message };
     };
     return {
-      compare: (el: any, expected: string): jasmine.CustomMatcherResult => {
+      compare: (el: unknown, expected: string): jasmine.CustomMatcherResult => {
         return assert(false, el, expected);
       },
-      negativeCompare: (el: any, expected: string): jasmine.CustomMatcherResult => {
+      negativeCompare: (el: unknown, expected: string): jasmine.CustomMatcherResult => {
         return assert(true, el, expected);
       }
     };
@@ -64,7 +64,7 @@ const speculoosMatchers: jasmine.CustomMatcherFactories = {
    * Checks that the receiver is a TestElement wrapping a DOM element and has the exact given textContent
    */
   toHaveText: (util: jasmine.MatchersUtil, customEqualityTesters: ReadonlyArray<jasmine.CustomEqualityTester>): jasmine.CustomMatcher => {
-    const assert = (isNegative: boolean, el: any, expected: string) => {
+    const assert = (isNegative: boolean, el: unknown, expected: string) => {
       if (!el) {
         return { pass: false, message: `Expected to check text '${expected}' on element, but element was falsy` };
       }
@@ -77,10 +77,10 @@ const speculoosMatchers: jasmine.CustomMatcherFactories = {
       return { pass: isNegative ? !pass : pass, message };
     };
     return {
-      compare: (el: any, expected: string): jasmine.CustomMatcherResult => {
+      compare: (el: unknown, expected: string): jasmine.CustomMatcherResult => {
         return assert(false, el, expected);
       },
-      negativeCompare: (el: any, expected: string): jasmine.CustomMatcherResult => {
+      negativeCompare: (el: unknown, expected: string): jasmine.CustomMatcherResult => {
         return assert(true, el, expected);
       }
     };
@@ -93,7 +93,7 @@ const speculoosMatchers: jasmine.CustomMatcherFactories = {
     util: jasmine.MatchersUtil,
     customEqualityTesters: ReadonlyArray<jasmine.CustomEqualityTester>
   ): jasmine.CustomMatcher => {
-    const assert = (isNegative: boolean, el: any, expected: string) => {
+    const assert = (isNegative: boolean, el: unknown, expected: string) => {
       if (!el) {
         return { pass: false, message: `Expected to check text '${expected}' on element, but element was falsy` };
       }
@@ -112,10 +112,10 @@ const speculoosMatchers: jasmine.CustomMatcherFactories = {
       return { pass: isNegative ? !pass : pass, message };
     };
     return {
-      compare: (el: any, expected: string): jasmine.CustomMatcherResult => {
+      compare: (el: unknown, expected: string): jasmine.CustomMatcherResult => {
         return assert(false, el, expected);
       },
-      negativeCompare: (el: any, expected: string): jasmine.CustomMatcherResult => {
+      negativeCompare: (el: unknown, expected: string): jasmine.CustomMatcherResult => {
         return assert(true, el, expected);
       }
     };
@@ -125,7 +125,7 @@ const speculoosMatchers: jasmine.CustomMatcherFactories = {
    * Checks that the receiver is a TestElement wrapping a DOM element and contains the given textContent
    */
   toBeChecked: (util: jasmine.MatchersUtil, customEqualityTesters: ReadonlyArray<jasmine.CustomEqualityTester>): jasmine.CustomMatcher => {
-    const assert = (isNegative: boolean, el: any) => {
+    const assert = (isNegative: boolean, el: unknown) => {
       if (!el) {
         return { pass: false, message: `Expected to check if element was checked, but element was falsy` };
       }
@@ -137,10 +137,10 @@ const speculoosMatchers: jasmine.CustomMatcherFactories = {
       return { pass: isNegative ? !pass : pass, message };
     };
     return {
-      compare: (el: any): jasmine.CustomMatcherResult => {
+      compare: (el: unknown): jasmine.CustomMatcherResult => {
         return assert(false, el);
       },
-      negativeCompare: (el: any): jasmine.CustomMatcherResult => {
+      negativeCompare: (el: unknown): jasmine.CustomMatcherResult => {
         return assert(true, el);
       }
     };
@@ -153,7 +153,7 @@ const speculoosMatchers: jasmine.CustomMatcherFactories = {
     util: jasmine.MatchersUtil,
     customEqualityTesters: ReadonlyArray<jasmine.CustomEqualityTester>
   ): jasmine.CustomMatcher => {
-    const assert = (isNegative: boolean, el: any, expected: number) => {
+    const assert = (isNegative: boolean, el: unknown, expected: number) => {
       if (!el) {
         return { pass: false, message: `Expected to check selected index ${expected} on element, but element was falsy` };
       }
@@ -166,10 +166,10 @@ const speculoosMatchers: jasmine.CustomMatcherFactories = {
       return { pass: isNegative ? !pass : pass, message };
     };
     return {
-      compare: (el: any, expected: number): jasmine.CustomMatcherResult => {
+      compare: (el: unknown, expected: number): jasmine.CustomMatcherResult => {
         return assert(false, el, expected);
       },
-      negativeCompare: (el: any, expected: number): jasmine.CustomMatcherResult => {
+      negativeCompare: (el: unknown, expected: number): jasmine.CustomMatcherResult => {
         return assert(true, el, expected);
       }
     };
@@ -182,7 +182,7 @@ const speculoosMatchers: jasmine.CustomMatcherFactories = {
     util: jasmine.MatchersUtil,
     customEqualityTesters: ReadonlyArray<jasmine.CustomEqualityTester>
   ): jasmine.CustomMatcher => {
-    const assert = (isNegative: boolean, el: any, expected: string) => {
+    const assert = (isNegative: boolean, el: unknown, expected: string) => {
       if (!el) {
         return { pass: false, message: `Expected to check selected value '${expected}' on element, but element was falsy` };
       }
@@ -195,10 +195,10 @@ const speculoosMatchers: jasmine.CustomMatcherFactories = {
       return { pass: isNegative ? !pass : pass, message };
     };
     return {
-      compare: (el: any, expected: string): jasmine.CustomMatcherResult => {
+      compare: (el: unknown, expected: string): jasmine.CustomMatcherResult => {
         return assert(false, el, expected);
       },
-      negativeCompare: (el: any, expected: string): jasmine.CustomMatcherResult => {
+      negativeCompare: (el: unknown, expected: string): jasmine.CustomMatcherResult => {
         return assert(true, el, expected);
       }
     };
@@ -211,7 +211,7 @@ const speculoosMatchers: jasmine.CustomMatcherFactories = {
     util: jasmine.MatchersUtil,
     customEqualityTesters: ReadonlyArray<jasmine.CustomEqualityTester>
   ): jasmine.CustomMatcher => {
-    const assert = (isNegative: boolean, el: any, expected: string) => {
+    const assert = (isNegative: boolean, el: unknown, expected: string) => {
       if (!el) {
         return { pass: false, message: `Expected to check selected label '${expected}' on element, but element was falsy` };
       }
@@ -224,10 +224,10 @@ const speculoosMatchers: jasmine.CustomMatcherFactories = {
       return { pass: isNegative ? !pass : pass, message };
     };
     return {
-      compare: (el: any, expected: string): jasmine.CustomMatcherResult => {
+      compare: (el: unknown, expected: string): jasmine.CustomMatcherResult => {
         return assert(false, el, expected);
       },
-      negativeCompare: (el: any, expected: string): jasmine.CustomMatcherResult => {
+      negativeCompare: (el: unknown, expected: string): jasmine.CustomMatcherResult => {
         return assert(true, el, expected);
       }
     };

--- a/projects/ngx-speculoos/src/lib/route.ts
+++ b/projects/ngx-speculoos/src/lib/route.ts
@@ -32,7 +32,7 @@ export function fakeRoute(options: {
   /** The outlet name of the route. It's a constant */
   outlet?: string;
   /** The component of the route. It's a constant */
-  component?: Type<any> | string | null;
+  component?: Type<unknown> | string | null;
   /** The current snapshot of this route */
   snapshot?: ActivatedRouteSnapshot;
   /** The configuration used to match this route */
@@ -67,18 +67,18 @@ export function fakeRoute(options: {
     pathFromRoot: options.pathFromRoot
   } as ActivatedRoute;
 
-  for (let route: any = result; !!route; route = route.parent) {
+  for (let route: null | ActivatedRoute = result; !!route; route = route.parent) {
     if (route.parent && route.parent.snapshot && !route.snapshot) {
       route.snapshot = fakeSnapshot({});
     }
     if (route.parent && route.parent.snapshot && !route.snapshot.parent) {
-      (route.snapshot as any).parent = route.parent.snapshot;
+      (route.snapshot as Omit<ActivatedRouteSnapshot, 'parent'> & { parent: ActivatedRouteSnapshot }).parent = route.parent.snapshot;
     }
 
     if (route.snapshot && route.snapshot.parent && !route.parent) {
-      route.parent = fakeRoute({});
+      (route as Omit<ActivatedRoute, 'parent'> & { parent: ActivatedRoute }).parent = fakeRoute({});
     }
-    if (route.snapshot && route.snapshot.parent && !route.parent.snapshot) {
+    if (route.snapshot && route.snapshot.parent && route.parent && !route.parent.snapshot) {
       route.parent.snapshot = route.snapshot.parent;
     }
   }
@@ -107,7 +107,7 @@ export function fakeSnapshot(options: {
   /** The outlet name of the route */
   outlet?: string;
   /** The component of the route */
-  component?: Type<any> | string | null;
+  component?: Type<unknown> | string | null;
   /** The configuration used to match this route */
   routeConfig?: Route;
   /** The root of the router state */

--- a/projects/ngx-speculoos/src/lib/test-button.ts
+++ b/projects/ngx-speculoos/src/lib/test-button.ts
@@ -6,7 +6,7 @@ import { DebugElement } from '@angular/core';
  * A wrapped button element, providing additional methods and attributes helping with writing tests
  */
 export class TestButton extends TestHtmlElement<HTMLButtonElement> {
-  constructor(tester: ComponentTester<any>, debugElement: DebugElement) {
+  constructor(tester: ComponentTester<unknown>, debugElement: DebugElement) {
     super(tester, debugElement);
   }
 

--- a/projects/ngx-speculoos/src/lib/test-element-querier.ts
+++ b/projects/ngx-speculoos/src/lib/test-element-querier.ts
@@ -13,10 +13,10 @@ import { By } from '@angular/platform-browser';
  */
 export class TestElementQuerier {
 
-  constructor(private tester: ComponentTester<any>,
+  constructor(private tester: ComponentTester<unknown>,
               private root: DebugElement) { }
 
-  static wrap(childDebugElement: DebugElement, tester: ComponentTester<any>): TestElement<any> {
+  static wrap(childDebugElement: DebugElement, tester: ComponentTester<unknown>): TestElement {
     const childElement = childDebugElement.nativeElement;
     if (childElement instanceof HTMLButtonElement) {
       return new TestButton(tester, childDebugElement);
@@ -41,7 +41,7 @@ export class TestElementQuerier {
    * @param selector a CSS selector
    * @returns the wrapped element, or null if no element matches the selector.
    */
-  element(selector: string): TestElement<Element> | null {
+  element(selector: string): TestElement | null {
     const childElement = this.query(selector);
     return childElement && TestElementQuerier.wrap(childElement, this.tester);
   }
@@ -54,7 +54,7 @@ export class TestElementQuerier {
    * @param selector a CSS selector
    * @returns the array of matched elements, empty if no element was matched
    */
-  elements(selector: string): Array<TestElement<Element>> {
+  elements(selector: string): Array<TestElement> {
     const childElements = this.queryAll(selector);
     return childElements.map(debugElement => TestElementQuerier.wrap(debugElement, this.tester));
   }

--- a/projects/ngx-speculoos/src/lib/test-element.spec.ts
+++ b/projects/ngx-speculoos/src/lib/test-element.spec.ts
@@ -24,7 +24,7 @@ import { TestInput } from './test-input';
   `
 })
 class TestComponent {
-  onChange($event) { }
+  onChange($event: Event) { }
 }
 
 class TestComponentTester extends ComponentTester<TestComponent> {
@@ -101,7 +101,7 @@ describe('TestElement', () => {
   });
 
   describe('queries', () => {
-    let parent: TestElement<any>;
+    let parent: TestElement;
 
     beforeEach(() => {
       parent = tester.parent;

--- a/projects/ngx-speculoos/src/lib/test-element.ts
+++ b/projects/ngx-speculoos/src/lib/test-element.ts
@@ -5,16 +5,17 @@ import { TestTextArea } from './test-textarea';
 import { TestInput } from './test-input';
 import { TestElementQuerier } from './test-element-querier';
 import { DebugElement } from '@angular/core';
+import { TestHtmlElement } from './test-html-element';
 
 /**
  * A wrapped DOM element, providing additional methods and attributes helping with writing tests
  */
-export class TestElement<E extends Element> {
+export class TestElement<E extends Element = Element> {
 
   private querier: TestElementQuerier;
 
   constructor(
-    protected tester: ComponentTester<any>,
+    protected tester: ComponentTester<unknown>,
     /**
      * the wrapped debug element
      */
@@ -68,24 +69,224 @@ export class TestElement<E extends Element> {
   /**
    * Gets the first element matching the given CSS selector and wraps it into a TestElement. The actual type
    * of the returned value is the TestElement subclass matching the type of the found element. So, if the
-   * matched element is an input for example, the method will return a TestInput. You can thus use
-   * `tester.element('#some-input') as TestInput`.
+   * matched element is an input for example, the method will return a TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElement: TestHtmlElement&lt;HTMLDivElement> | null = tester.element('div');
+   * </code>
    * @param selector a CSS selector
    * @returns the wrapped element, or null if no element matches the selector.
    */
-  element(selector: string): TestElement<Element> | null {
+  element<K extends keyof HTMLElementTagNameMap>(selector: K): TestHtmlElement<HTMLElementTagNameMap[K]> | null;
+  /**
+   * Gets the first element matching the given CSS selector and wraps it into a TestElement. The actual type
+   * of the returned value is the TestElement subclass matching the type of the found element. So, if the
+   * matched element is an input for example, the method will return a TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElement: TestElement&lt;SVGLineElement> | null = tester.element('line');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the wrapped element, or null if no element matches the selector.
+   */
+  element<K extends keyof SVGElementTagNameMap>(selector: K): TestElement<SVGElementTagNameMap[K]> | null;
+  /**
+   * Gets the first element matching the given CSS selector and wraps it into a TestElement. The actual type
+   * of the returned value is the TestElement subclass matching the type of the found element. So, if the
+   * matched element is an input for example, the method will return a TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElement: TestElement | null = tester.element('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the wrapped element, or null if no element matches the selector.
+   */
+  element(selector: string): TestElement | null;
+  /**
+   * Gets the first element matching the given CSS selector and wraps it into a TestElement. The actual type
+   * of the returned value is the TestElement subclass matching the type of the found element. So, if the
+   * matched element is an input for example, the method will return a TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElement: TestInput | null = tester.element&lt;HTMLInputElement>('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the wrapped element, or null if no element matches the selector.
+   */
+  element<T extends HTMLInputElement>(selector: string): TestInput | null;
+  /**
+   * Gets the first element matching the given CSS selector and wraps it into a TestElement. The actual type
+   * of the returned value is the TestElement subclass matching the type of the found element. So, if the
+   * matched element is an input for example, the method will return a TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElement: TestTextArea | null = tester.element&lt;HTMLTextAreaElement>('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the wrapped element, or null if no element matches the selector.
+   */
+  element<T extends HTMLTextAreaElement>(selector: string): TestTextArea | null;
+  /**
+   * Gets the first element matching the given CSS selector and wraps it into a TestElement. The actual type
+   * of the returned value is the TestElement subclass matching the type of the found element. So, if the
+   * matched element is an input for example, the method will return a TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElement: TestSelect | null = tester.element&lt;HTMLSelectElement>('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the wrapped element, or null if no element matches the selector.
+   */
+  element<T extends HTMLSelectElement>(selector: string): TestSelect | null;
+  /**
+   * Gets the first element matching the given CSS selector and wraps it into a TestElement. The actual type
+   * of the returned value is the TestElement subclass matching the type of the found element. So, if the
+   * matched element is an input for example, the method will return a TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElement: TestButton | null = tester.element&lt;HTMLButtonElement>('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the wrapped element, or null if no element matches the selector.
+   */
+  element<T extends HTMLButtonElement>(selector: string): TestButton | null;
+  /**
+   * Gets the first element matching the given CSS selector and wraps it into a TestElement. The actual type
+   * of the returned value is the TestElement subclass matching the type of the found element. So, if the
+   * matched element is an input for example, the method will return a TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElement: TestHtmlElement&lt;HTMLDivElement> | null = tester.element&lt;HTMLDivElement>('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the wrapped element, or null if no element matches the selector.
+   */
+  element<T extends HTMLElement>(selector: string): TestHtmlElement<T> | null;
+  /**
+   * Gets the first element matching the given CSS selector and wraps it into a TestElement. The actual type
+   * of the returned value is the TestElement subclass matching the type of the found element. So, if the
+   * matched element is an input for example, the method will return a TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElement: TestElement&lt;SVGLineElement> | null = tester.element&lt;SVGLineElement>('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the wrapped element, or null if no element matches the selector.
+   */
+  element<T extends Element>(selector: string): TestElement<T> | null;
+  element(selector: string): TestElement | null {
     return this.querier.element(selector);
   }
 
   /**
    * Gets all the elements matching the given CSS selector and wraps them into a TestElement. The actual type
    * of the returned elements is the TestElement subclass matching the type of the found element. So, if the
-   * matched elements are inputs for example, the method will return an array of TestInput. You can thus use
-   * `tester.elements('input') as Array<TestInput>`.
+   * matched elements are inputs for example, the method will return an array of TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElements: Array&lt;TestHtmlElement&lt;HTMLDivElement>> = tester.elements('div');
+   * </code>
    * @param selector a CSS selector
    * @returns the array of matched elements, empty if no element was matched
    */
-  elements(selector: string): Array<TestElement<Element>> {
+  elements<K extends keyof HTMLElementTagNameMap>(selector: K): Array<TestHtmlElement<HTMLElementTagNameMap[K]>>;
+  /**
+   * Gets all the elements matching the given CSS selector and wraps them into a TestElement. The actual type
+   * of the returned elements is the TestElement subclass matching the type of the found element. So, if the
+   * matched elements are inputs for example, the method will return an array of TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElements: Array&lt;TestElement&lt;SVGLineElement>> = tester.elements('line');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the array of matched elements, empty if no element was matched
+   */
+  elements<K extends keyof SVGElementTagNameMap>(selector: K): Array<TestElement<SVGElementTagNameMap[K]>>;
+  /**
+   * Gets all the elements matching the given CSS selector and wraps them into a TestElement. The actual type
+   * of the returned elements is the TestElement subclass matching the type of the found element. So, if the
+   * matched elements are inputs for example, the method will return an array of TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElements: Array&lt;TestElement> = tester.elements('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the array of matched elements, empty if no element was matched
+   */
+  elements(selector: string): Array<TestElement>;
+  /**
+   * Gets all the elements matching the given CSS selector and wraps them into a TestElement. The actual type
+   * of the returned elements is the TestElement subclass matching the type of the found element. So, if the
+   * matched elements are inputs for example, the method will return an array of TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElements: Array&lt;TestInput> = tester.elements&lt;HTMLInputElement>('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the array of matched elements, empty if no element was matched
+   */
+  elements<T extends HTMLInputElement>(selector: string): Array<TestInput>;
+  /**
+   * Gets all the elements matching the given CSS selector and wraps them into a TestElement. The actual type
+   * of the returned elements is the TestElement subclass matching the type of the found element. So, if the
+   * matched elements are inputs for example, the method will return an array of TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElements: Array&lt;TestTextArea> = tester.elements&lt;HTMLTextAreaElement>('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the array of matched elements, empty if no element was matched
+   */
+  elements<T extends HTMLTextAreaElement>(selector: string): Array<TestTextArea>;
+  /**
+   * Gets all the elements matching the given CSS selector and wraps them into a TestElement. The actual type
+   * of the returned elements is the TestElement subclass matching the type of the found element. So, if the
+   * matched elements are inputs for example, the method will return an array of TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElements: Array&lt;TestButton> = tester.elements&lt;HTMLButtonElement>('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the array of matched elements, empty if no element was matched
+   */
+  elements<T extends HTMLButtonElement>(selector: string): Array<TestButton>;
+  /**
+   * Gets all the elements matching the given CSS selector and wraps them into a TestElement. The actual type
+   * of the returned elements is the TestElement subclass matching the type of the found element. So, if the
+   * matched elements are inputs for example, the method will return an array of TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElements: Array&lt;TestSelect> = tester.elements<HTMLSelectElement>('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the array of matched elements, empty if no element was matched
+   */
+  elements<T extends HTMLSelectElement>(selector: string): Array<TestSelect>;
+  /**
+   * Gets all the elements matching the given CSS selector and wraps them into a TestElement. The actual type
+   * of the returned elements is the TestElement subclass matching the type of the found element. So, if the
+   * matched elements are inputs for example, the method will return an array of TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElements: Array&lt;TestHtmlElement&lt;HTMLDivElement>> = tester.elements&lt;HTMLDivElement>('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the array of matched elements, empty if no element was matched
+   */
+  elements<T extends HTMLElement>(selector: string): Array<TestHtmlElement<T>>;
+  /**
+   * Gets all the elements matching the given CSS selector and wraps them into a TestElement. The actual type
+   * of the returned elements is the TestElement subclass matching the type of the found element. So, if the
+   * matched elements are inputs for example, the method will return an array of TestInput.
+   * <p>Usage:</p>
+   * <code>
+   * const testElements: Array&lt;TestElement&lt;SVGLineElement>> = tester.elements&lt;SVGLineElement>('.selector');
+   * </code>
+   * @param selector a CSS selector
+   * @returns the array of matched elements, empty if no element was matched
+   */
+  elements<T extends Element>(selector: string): Array<TestElement<T>>;
+  elements(selector: string): Array<TestElement> {
     return this.querier.elements(selector);
   }
 

--- a/projects/ngx-speculoos/src/lib/test-html-element.spec.ts
+++ b/projects/ngx-speculoos/src/lib/test-html-element.spec.ts
@@ -10,7 +10,7 @@ import { TestHtmlElement } from './test-html-element';
   `
 })
 class TestComponent {
-  onClick($event) { }
+  onClick($event: Event) { }
 }
 
 class TestComponentTester extends ComponentTester<TestComponent> {

--- a/projects/ngx-speculoos/src/lib/test-html-element.ts
+++ b/projects/ngx-speculoos/src/lib/test-html-element.ts
@@ -6,7 +6,7 @@ import { DebugElement } from '@angular/core';
  * A wrapped DOM HTML element, providing additional methods and attributes helping with writing tests
  */
 export class TestHtmlElement<E extends HTMLElement> extends TestElement<E> {
-  constructor(tester: ComponentTester<any>, debugElement: DebugElement) {
+  constructor(tester: ComponentTester<unknown>, debugElement: DebugElement) {
     super(tester, debugElement);
   }
 

--- a/projects/ngx-speculoos/src/lib/test-input.ts
+++ b/projects/ngx-speculoos/src/lib/test-input.ts
@@ -6,7 +6,7 @@ import { DebugElement } from '@angular/core';
  * A wrapped DOM HTML input element, providing additional methods and attributes helping with writing tests
  */
 export class TestInput extends TestHtmlElement<HTMLInputElement> {
-  constructor(tester: ComponentTester<any>, debugElement: DebugElement) {
+  constructor(tester: ComponentTester<unknown>, debugElement: DebugElement) {
     super(tester, debugElement);
   }
 

--- a/projects/ngx-speculoos/src/lib/test-select.ts
+++ b/projects/ngx-speculoos/src/lib/test-select.ts
@@ -6,7 +6,7 @@ import { DebugElement } from '@angular/core';
  * A wrapped DOM HTML select element, providing additional methods and attributes helping with writing tests
  */
 export class TestSelect extends TestHtmlElement<HTMLSelectElement> {
-  constructor(tester: ComponentTester<any>, debugElement: DebugElement) {
+  constructor(tester: ComponentTester<unknown>, debugElement: DebugElement) {
     super(tester, debugElement);
   }
 

--- a/projects/ngx-speculoos/src/lib/test-textarea.ts
+++ b/projects/ngx-speculoos/src/lib/test-textarea.ts
@@ -6,7 +6,7 @@ import { DebugElement } from '@angular/core';
  * A wrapped DOM HTML textarea element, providing additional methods and attributes helping with writing tests
  */
 export class TestTextArea extends TestHtmlElement<HTMLTextAreaElement> {
-  constructor(tester: ComponentTester<any>, debugElement: DebugElement) {
+  constructor(tester: ComponentTester<unknown>, debugElement: DebugElement) {
     super(tester, debugElement);
   }
 

--- a/projects/ngx-speculoos/src/public_api.ts
+++ b/projects/ngx-speculoos/src/public_api.ts
@@ -10,5 +10,6 @@ export * from './lib/test-html-element';
 export * from './lib/test-input';
 export * from './lib/test-button';
 export * from './lib/test-select';
+export * from './lib/test-textarea';
 export * from './lib/route';
 export * from './lib/matchers';

--- a/projects/ngx-speculoos/src/test.ts
+++ b/projects/ngx-speculoos/src/test.ts
@@ -8,13 +8,19 @@ import {
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
 
-declare const require: any;
+declare const require: {
+  context(
+    path: string,
+    deep?: boolean,
+    filter?: RegExp
+  ): {
+    keys(): Array<string>;
+    <T>(id: string): T;
+  };
+};
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
-);
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.

--- a/projects/ngx-speculoos/tsconfig.spec.json
+++ b/projects/ngx-speculoos/tsconfig.spec.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../out-tsc/spec",
+    "strictNullChecks": false,
     "types": [
       "jasmine",
       "node"

--- a/projects/tsd-test/index.d.ts
+++ b/projects/tsd-test/index.d.ts
@@ -1,0 +1,1 @@
+export * from '../../dist/ngx-speculoos/ngx-speculoos';

--- a/projects/tsd-test/index.test-d.ts
+++ b/projects/tsd-test/index.test-d.ts
@@ -1,0 +1,30 @@
+import { expectType } from 'tsd';
+import { ComponentTester, TestButton, TestElement, TestHtmlElement, TestInput, TestSelect, TestTextArea } from './';
+
+// @ts-ignore
+const componentTester: ComponentTester<unknown> = null;
+// @ts-ignore
+const testElement: TestElement = null;
+[componentTester, testElement].forEach(test => {
+  // element
+  expectType<TestHtmlElement<HTMLDivElement> | null>(test.element('div'));
+  expectType<TestElement<SVGLineElement> | null>(test.element('line'));
+  expectType<TestElement | null>(test.element('.any-selector'));
+  expectType<TestHtmlElement<HTMLDivElement> | null>(test.element<HTMLDivElement>('.any-selector'));
+  expectType<TestElement<SVGLineElement> | null>(test.element<SVGLineElement>('.any-selector'));
+  expectType<TestInput | null>(test.element<HTMLInputElement>('.any-selector'));
+  expectType<TestTextArea | null>(test.element<HTMLTextAreaElement>('.any-selector'));
+  expectType<TestButton | null>(test.element<HTMLButtonElement>('.any-selector'));
+  expectType<TestSelect | null>(test.element<HTMLSelectElement>('.any-selector'));
+
+  // elements
+  expectType<Array<TestHtmlElement<HTMLDivElement>>>(test.elements('div'));
+  expectType<Array<TestElement<SVGLineElement>>>(test.elements('line'));
+  expectType<Array<TestElement>>(test.elements('.any-selector'));
+  expectType<Array<TestHtmlElement<HTMLDivElement>>>(test.elements<HTMLDivElement>('.any-selector'));
+  expectType<Array<TestElement<SVGLineElement>>>(test.elements<SVGLineElement>('.any-selector'));
+  expectType<Array<TestInput>>(test.elements<HTMLInputElement>('.any-selector'));
+  expectType<Array<TestTextArea>>(test.elements<HTMLTextAreaElement>('.any-selector'));
+  expectType<Array<TestButton>>(test.elements<HTMLButtonElement>('.any-selector'));
+  expectType<Array<TestSelect>>(test.elements<HTMLSelectElement>('.any-selector'));
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,6 +3,10 @@
   "compilerOptions": {
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
     "sourceMap": true,
     "declaration": false,
     "module": "esnext",

--- a/tslint.json
+++ b/tslint.json
@@ -50,6 +50,7 @@
         ]
       }
     ],
+    "no-any": true,
     "no-consecutive-blank-lines": false,
     "no-console": [
       true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1892,6 +1892,13 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
+ansi-align@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"
+  integrity sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=
+  dependencies:
+    string-width "^2.0.0"
+
 ansi-align@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb"
@@ -1916,6 +1923,11 @@ ansi-colors@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
   integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
 
+ansi-escapes@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-2.0.0.tgz#5bae52be424878dd9783e8910e3fc2922e83c81b"
+  integrity sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=
+
 ansi-escapes@^4.2.1:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.0.tgz#a4ce2b33d6b214b7950d8595c212f12ac9cc569d"
@@ -1939,6 +1951,11 @@ ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
   integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
+
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
 ansi-regex@^4.1.0:
   version "4.1.0"
@@ -2083,7 +2100,7 @@ array-ify@^1.0.0:
   resolved "https://registry.yarnpkg.com/array-ify/-/array-ify-1.0.0.tgz#9e528762b4a9066ad163a6962a364418e9626ece"
   integrity sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=
 
-array-union@^1.0.1:
+array-union@^1.0.1, array-union@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
   integrity sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=
@@ -2424,6 +2441,19 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+
+boxen@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.3.0.tgz#55c6c39a8ba58d9c61ad22cd877532deb665a20b"
+  integrity sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==
+  dependencies:
+    ansi-align "^2.0.0"
+    camelcase "^4.0.0"
+    chalk "^2.0.1"
+    cli-boxes "^1.0.0"
+    string-width "^2.0.0"
+    term-size "^1.2.0"
+    widest-line "^2.0.0"
 
 boxen@^4.2.0:
   version "4.2.0"
@@ -2852,7 +2882,7 @@ camelcase@^2.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
   integrity sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=
 
-camelcase@^4.1.0:
+camelcase@^4.0.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
@@ -2892,12 +2922,17 @@ canonical-path@1.0.0:
   resolved "https://registry.yarnpkg.com/canonical-path/-/canonical-path-1.0.0.tgz#fcb470c23958def85081856be7a86e904f180d1d"
   integrity sha512-feylzsbDxi1gPZ1IjystzIQZagYYLvfKrSuygUCgf7z6x790VEzze5QEkdSV1U58RA7Hi0+v6fv4K54atOzATg==
 
+capture-stack-trace@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz#a6c0bbe1f38f3aa0b92238ecb6ff42c344d4135d"
+  integrity sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -3005,6 +3040,11 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
+ci-info@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
+  integrity sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==
+
 ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
@@ -3037,6 +3077,11 @@ clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
+
+cli-boxes@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
+  integrity sha1-T6kXw+WclKAEzWH47lCdplFocUM=
 
 cli-boxes@^2.2.0:
   version "2.2.0"
@@ -3313,6 +3358,18 @@ concat-stream@^2.0.0:
     inherits "^2.0.3"
     readable-stream "^3.0.2"
     typedarray "^0.0.6"
+
+configstore@^3.0.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/configstore/-/configstore-3.1.2.tgz#c6f25defaeef26df12dd33414b001fe81a543f8f"
+  integrity sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==
+  dependencies:
+    dot-prop "^4.1.0"
+    graceful-fs "^4.1.2"
+    make-dir "^1.0.0"
+    unique-string "^1.0.0"
+    write-file-atomic "^2.0.0"
+    xdg-basedir "^3.0.0"
 
 configstore@^5.0.0:
   version "5.0.0"
@@ -3638,6 +3695,13 @@ create-ecdh@^4.0.0:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
 
+create-error-class@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
+  integrity sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=
+  dependencies:
+    capture-stack-trace "^1.0.0"
+
 create-hash@^1.1.0, create-hash@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
@@ -3660,6 +3724,15 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
 
 cross-spawn@^6.0.0:
   version "6.0.5"
@@ -3693,6 +3766,11 @@ crypto-js@^3.1.9-1:
   version "3.1.9-1"
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
   integrity sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=
+
+crypto-random-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
+  integrity sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=
 
 crypto-random-string@^2.0.0:
   version "2.0.0"
@@ -4217,6 +4295,13 @@ dir-glob@2.0.0:
     arrify "^1.0.1"
     path-type "^3.0.0"
 
+dir-glob@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.2.2.tgz#fa09f0694153c8918b18ba0deafae94769fc50c4"
+  integrity sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==
+  dependencies:
+    path-type "^3.0.0"
+
 dir-glob@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
@@ -4315,7 +4400,7 @@ dot-prop@^3.0.0:
   dependencies:
     is-obj "^1.0.0"
 
-dot-prop@^4.1.1:
+dot-prop@^4.1.0, dot-prop@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
   integrity sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==
@@ -4682,6 +4767,17 @@ escodegen@~1.9.0:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-formatter-pretty@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-formatter-pretty/-/eslint-formatter-pretty-1.3.0.tgz#985d9e41c1f8475f4a090c5dbd2dfcf2821d607e"
+  integrity sha512-5DY64Y1rYCm7cfFDHEGUn54bvCnK+wSUVF07N8oXeqUJFSd+gnYOTXbzelQ1HurESluY6gnEQPmXOIkB4Wa+gA==
+  dependencies:
+    ansi-escapes "^2.0.0"
+    chalk "^2.1.0"
+    log-symbols "^2.0.0"
+    plur "^2.1.2"
+    string-width "^2.0.0"
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
@@ -4792,6 +4888,19 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   dependencies:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
+
+execa@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
+  integrity sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
 
 execa@^1.0.0:
   version "1.0.0"
@@ -4940,7 +5049,7 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
   integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
 
-fast-glob@^2.0.2:
+fast-glob@^2.0.2, fast-glob@^2.2.6:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.7.tgz#6953857c3afa475fff92ee6015d52da70a4cd39d"
   integrity sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==
@@ -5345,6 +5454,11 @@ get-stdin@^4.0.1:
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
   integrity sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=
 
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+  integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
+
 get-stream@^4.0.0, get-stream@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
@@ -5444,6 +5558,13 @@ glob@7.1.6, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glo
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+global-dirs@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445"
+  integrity sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=
+  dependencies:
+    ini "^1.3.4"
+
 global-dirs@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-2.0.1.tgz#acdf3bb6685bcd55cb35e8a052266569e9469201"
@@ -5491,6 +5612,37 @@ globby@^8.0.1:
     ignore "^3.3.5"
     pify "^3.0.0"
     slash "^1.0.0"
+
+globby@^9.1.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-9.2.0.tgz#fd029a706c703d29bdd170f4b6db3a3f7a7cb63d"
+  integrity sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==
+  dependencies:
+    "@types/glob" "^7.1.1"
+    array-union "^1.0.2"
+    dir-glob "^2.2.2"
+    fast-glob "^2.2.6"
+    glob "^7.1.3"
+    ignore "^4.0.3"
+    pify "^4.0.1"
+    slash "^2.0.0"
+
+got@^6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
+  integrity sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=
+  dependencies:
+    create-error-class "^3.0.0"
+    duplexer3 "^0.1.4"
+    get-stream "^3.0.0"
+    is-redirect "^1.0.0"
+    is-retry-allowed "^1.0.0"
+    is-stream "^1.0.0"
+    lowercase-keys "^1.0.0"
+    safe-buffer "^5.0.1"
+    timed-out "^4.0.0"
+    unzip-response "^2.0.1"
+    url-parse-lax "^1.0.0"
 
 got@^9.6.0:
   version "9.6.0"
@@ -5910,6 +6062,11 @@ ignore@^3.3.5:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
   integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
 
+ignore@^4.0.3:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
+  integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
 ignore@^5.1.4:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
@@ -6015,7 +6172,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@1.3.5, ini@^1.3.2, ini@^1.3.5, ini@~1.3.0:
+ini@1.3.5, ini@^1.3.2, ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -6083,6 +6240,11 @@ ipaddr.js@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
+
+irregular-plurals@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/irregular-plurals/-/irregular-plurals-1.4.0.tgz#2ca9b033651111855412f16be5d77c62a458a766"
+  integrity sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=
 
 is-absolute-url@^2.0.0:
   version "2.1.0"
@@ -6154,6 +6316,13 @@ is-callable@^1.1.4, is-callable@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.5.tgz#f7e46b596890456db74e7f6e976cb3273d06faab"
   integrity sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==
+
+is-ci@^1.0.10:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.1.tgz#e3779c8ee17fccf428488f6e281187f2e632841c"
+  integrity sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==
+  dependencies:
+    ci-info "^1.5.0"
 
 is-ci@^2.0.0:
   version "2.0.0"
@@ -6267,6 +6436,14 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-installed-globally@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.1.0.tgz#0dfd98f5a9111716dd535dda6492f67bf3d25a80"
+  integrity sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=
+  dependencies:
+    global-dirs "^0.1.0"
+    is-path-inside "^1.0.0"
+
 is-installed-globally@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.3.1.tgz#679afef819347a72584617fd19497f010b8ed35f"
@@ -6289,6 +6466,11 @@ is-negated-glob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-negated-glob/-/is-negated-glob-1.0.0.tgz#6910bca5da8c95e784b5751b976cf5a10fee36d2"
   integrity sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=
+
+is-npm@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
+  integrity sha1-8vtjpl5JBbQGyGBydloaTceTufQ=
 
 is-npm@^4.0.0:
   version "4.0.0"
@@ -6329,6 +6511,13 @@ is-path-in-cwd@^2.0.0:
   dependencies:
     is-path-inside "^2.1.0"
 
+is-path-inside@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
+  integrity sha1-jvW33lBDej/cprToZe96pVy0gDY=
+  dependencies:
+    path-is-inside "^1.0.1"
+
 is-path-inside@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-2.1.0.tgz#7c9810587d659a40d27bcdb4d5616eab059494b2"
@@ -6358,6 +6547,11 @@ is-promise@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
   integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
 
+is-redirect@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
+  integrity sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=
+
 is-reference@^1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.1.4.tgz#3f95849886ddb70256a3e6d062b1a68c13c51427"
@@ -6384,7 +6578,12 @@ is-resolvable@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
   integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
 
-is-stream@^1.1.0:
+is-retry-allowed@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz#d778488bd0a4666a3be8a1482b9f2baafedea8b4"
+  integrity sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==
+
+is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -6781,6 +6980,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
+latest-version@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15"
+  integrity sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=
+  dependencies:
+    package-json "^4.0.0"
+
 latest-version@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-5.1.0.tgz#119dfe908fe38d15dfa43ecd13fa12ec8832face"
@@ -7018,6 +7224,13 @@ lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
+log-symbols@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
+  integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
+  dependencies:
+    chalk "^2.0.1"
+
 log-symbols@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-3.0.0.tgz#f3a08516a5dea893336a7dee14d18a1cfdab77c4"
@@ -7076,6 +7289,14 @@ lowercase-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
+lru-cache@^4.0.1:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -7113,6 +7334,13 @@ magic-string@^0.25.0, magic-string@^0.25.2:
   integrity sha512-3a5LOMSGoCTH5rbqobC2HuDNRtE2glHZ8J7pK+QZYppyWA36yuNpsX994rIY2nCuyP7CZYy7lQq/X2jygiZ89g==
   dependencies:
     sourcemap-codec "^1.4.4"
+
+make-dir@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
+  integrity sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==
+  dependencies:
+    pify "^3.0.0"
 
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
@@ -8223,6 +8451,16 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+package-json@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/package-json/-/package-json-4.0.1.tgz#8869a0401253661c4c4ca3da6c2121ed555f5eed"
+  integrity sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=
+  dependencies:
+    got "^6.7.1"
+    registry-auth-token "^3.0.1"
+    registry-url "^3.0.3"
+    semver "^5.1.0"
+
 package-json@^6.3.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/package-json/-/package-json-6.5.0.tgz#6feedaca35e75725876d0b0e64974697fed145b0"
@@ -8403,7 +8641,7 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-path-is-inside@^1.0.2:
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
   integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
@@ -8551,6 +8789,13 @@ pkg-up@^3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
+
+plur@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/plur/-/plur-2.1.2.tgz#7482452c1a0f508e3e344eaec312c91c29dc655a"
+  integrity sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=
+  dependencies:
+    irregular-plurals "^1.0.0"
 
 png-js@^1.0.0:
   version "1.0.0"
@@ -8985,7 +9230,7 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prepend-http@^1.0.0:
+prepend-http@^1.0.0, prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
@@ -9054,6 +9299,11 @@ prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
+
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
 psl@^1.1.24:
   version "1.7.0"
@@ -9207,7 +9457,7 @@ raw-loader@4.0.1:
     loader-utils "^2.0.0"
     schema-utils "^2.6.5"
 
-rc@^1.2.8:
+rc@^1.0.1, rc@^1.1.6, rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -9259,6 +9509,14 @@ read-pkg-up@^3.0.0:
   integrity sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=
   dependencies:
     find-up "^2.0.0"
+    read-pkg "^3.0.0"
+
+read-pkg-up@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-4.0.0.tgz#1b221c6088ba7799601c808f91161c66e58f8978"
+  integrity sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==
+  dependencies:
+    find-up "^3.0.0"
     read-pkg "^3.0.0"
 
 read-pkg-up@^5.0.0:
@@ -9469,12 +9727,27 @@ regexpu-core@^4.7.0:
     unicode-match-property-ecmascript "^1.0.4"
     unicode-match-property-value-ecmascript "^1.2.0"
 
+registry-auth-token@^3.0.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.4.0.tgz#d7446815433f5d5ed6431cd5dca21048f66b397e"
+  integrity sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==
+  dependencies:
+    rc "^1.1.6"
+    safe-buffer "^5.0.1"
+
 registry-auth-token@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-4.1.1.tgz#40a33be1e82539460f94328b0f7f0f84c16d9479"
   integrity sha512-9bKS7nTl9+/A1s7tnPeGrUpRcVY+LUh7bfFgzpndALdPfXQBfQV77rQVtqgUV3ti4vc/Ik81Ex8UJDWDQ12zQA==
   dependencies:
     rc "^1.2.8"
+
+registry-url@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
+  integrity sha1-PU74cPc93h138M+aOBQyRE4XSUI=
+  dependencies:
+    rc "^1.0.1"
 
 registry-url@^5.0.0:
   version "5.1.0"
@@ -9898,6 +10171,13 @@ selfsigned@^1.10.7:
   dependencies:
     node-forge "0.9.0"
 
+semver-diff@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
+  integrity sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=
+  dependencies:
+    semver "^5.0.3"
+
 semver-diff@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-3.1.1.tgz#05f77ce59f325e00e2706afd67bb506ddb1ca32b"
@@ -9919,7 +10199,7 @@ semver-intersect@1.4.0:
   dependencies:
     semver "^5.0.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.0.0, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -10081,6 +10361,11 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
   integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slash@^3.0.0:
   version "3.0.0"
@@ -10581,6 +10866,14 @@ strict-uri-encode@^1.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
 
+string-width@^2.0.0, string-width@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+  integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^4.0.0"
+
 string-width@^3.0.0, string-width@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
@@ -10640,6 +10933,13 @@ strip-ansi@^3.0.1:
   integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
+  dependencies:
+    ansi-regex "^3.0.0"
 
 strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
@@ -10827,6 +11127,13 @@ teeny-request@6.0.1:
     stream-events "^1.0.5"
     uuid "^3.3.2"
 
+term-size@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
+  integrity sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=
+  dependencies:
+    execa "^0.7.0"
+
 term-size@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.2.0.tgz#1f16adedfe9bdc18800e1776821734086fcc6753"
@@ -10923,6 +11230,11 @@ time-stamp@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-1.1.0.tgz#764a5a11af50561921b133f3b44e618687e0f5c3"
   integrity sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=
+
+timed-out@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
+  integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
 
 timers-browserify@^2.0.4:
   version "2.0.11"
@@ -11083,6 +11395,18 @@ ts-simple-ast@12.4.0:
     object-assign "^4.1.1"
     tslib "^1.9.0"
     typescript "2.9.1"
+
+tsd@0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/tsd/-/tsd-0.11.0.tgz#ede8b8e85850845b753fff7eaaf68dbd3673700b"
+  integrity sha512-klKMNC0KRzUIaLJG8XqkvH/9rKwYX74xpqJBN8spWjYUDojAesd6AfDCT5dray+yhLfTGkem7O3nU6i4KwzNDw==
+  dependencies:
+    eslint-formatter-pretty "^1.3.0"
+    globby "^9.1.0"
+    meow "^5.0.0"
+    path-exists "^3.0.0"
+    read-pkg-up "^4.0.0"
+    update-notifier "^2.5.0"
 
 tslib@2.0.0, tslib@^2.0.0:
   version "2.0.0"
@@ -11316,6 +11640,13 @@ unique-slug@^2.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
+unique-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
+  integrity sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=
+  dependencies:
+    crypto-random-string "^1.0.0"
+
 unique-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-2.0.0.tgz#39c6451f81afb2749de2b233e3f7c5e8843bd89d"
@@ -11365,10 +11696,31 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
+unzip-response@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
+  integrity sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=
+
 upath@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
+
+update-notifier@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.5.0.tgz#d0744593e13f161e406acb1d9408b72cad08aff6"
+  integrity sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==
+  dependencies:
+    boxen "^1.2.1"
+    chalk "^2.0.1"
+    configstore "^3.0.0"
+    import-lazy "^2.1.0"
+    is-ci "^1.0.10"
+    is-installed-globally "^0.1.0"
+    is-npm "^1.0.0"
+    latest-version "^3.0.0"
+    semver-diff "^2.0.0"
+    xdg-basedir "^3.0.0"
 
 update-notifier@^4.0.0:
   version "4.0.0"
@@ -11399,6 +11751,13 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+url-parse-lax@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
+  integrity sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=
+  dependencies:
+    prepend-http "^1.0.1"
 
 url-parse-lax@^3.0.0:
   version "3.0.0"
@@ -11736,6 +12095,13 @@ which@^1.2.1, which@^1.2.9, which@^1.3.1:
   dependencies:
     isexe "^2.0.0"
 
+widest-line@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-2.0.1.tgz#7438764730ec7ef4381ce4df82fb98a53142a3fc"
+  integrity sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==
+  dependencies:
+    string-width "^2.1.1"
+
 widest-line@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-3.1.0.tgz#8292333bbf66cb45ff0de1603b136b7ae1496eca"
@@ -11797,6 +12163,15 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
+write-file-atomic@^2.0.0:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.3.tgz#1fd2e9ae1df3e75b8d8c367443c692d4ca81f481"
+  integrity sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.2"
+
 write-file-atomic@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.1.tgz#558328352e673b5bb192cf86500d60b230667d4b"
@@ -11826,6 +12201,11 @@ ws@~6.1.0:
   dependencies:
     async-limiter "~1.0.0"
 
+xdg-basedir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
+  integrity sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=
+
 xdg-basedir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
@@ -11852,6 +12232,11 @@ y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
 yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"


### PR DESCRIPTION
We now properly infer (if possible) the type of the queried element(s).
For example:

    const testElement = tester.element('div'); // inferred as TestHtmlElement<HTMLDivElement> | null
    const testLink = tester.element<HTMLAnchorElement>('.selector'); // inferred as TestHtmlElement<HTMLAnchorElement> | null
    const testButtons = tester.elements<HTMLButtonElement>('.btn'); // inferred as Array<TestButton>
    const testElements = tester.elements('div'); // inferred as Array<TestHtmlElement<HTMLDivElement>>
    const testLinks = tester.elements<HTMLAnchorElement>('.selector'); // inferred as Array<TestHtmlElement<HTMLAnchorElement>>