### PR TITLE
chore: remove build-ng-packagr

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -10,7 +10,7 @@
       "prefix": "lib",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-ng-packagr:build",
+          "builder": "@angular-devkit/build-angular:ng-packagr",
           "options": {
             "tsConfig": "projects/ngx-speculoos/tsconfig.lib.json",
             "project": "projects/ngx-speculoos/ng-package.json"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "0.1001.0",
-    "@angular-devkit/build-ng-packagr": "0.1001.0",
     "@angular/cli": "10.1.0",
     "@angular/compiler-cli": "10.1.0",
     "@compodoc/compodoc": "1.1.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,14 +81,6 @@
     webpack-subresource-integrity "1.4.1"
     worker-plugin "5.0.0"
 
-"@angular-devkit/build-ng-packagr@0.1001.0":
-  version "0.1001.0"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/build-ng-packagr/-/build-ng-packagr-0.1001.0.tgz#11c0f4f681f3fe87879bf79bbc8df128e8bf8823"
-  integrity sha512-zFe/pVkmrg9L/ZIP/htJDCEkg/KmuZKwWsb0YXCi4U+zoX3Sm1TJCYTbzwazU7jsEHD6KeBhrtOfOaxaxfyFjQ==
-  dependencies:
-    "@angular-devkit/architect" "0.1001.0"
-    rxjs "6.6.2"
-
 "@angular-devkit/build-optimizer@0.1001.0":
   version "0.1001.0"
   resolved "https://registry.yarnpkg.com/@angular-devkit/build-optimizer/-/build-optimizer-0.1001.0.tgz#0e018138ec33e47b9cfbceb67ae0a5fbd5a26f08"


### PR DESCRIPTION
It has been deprecated and replaced by build-angular:ng-packagr