### PR TITLE
feat: throw when selecting invalid index, value or label

### DIFF
--- a/projects/ngx-speculoos/src/lib/test-select.spec.ts
+++ b/projects/ngx-speculoos/src/lib/test-select.spec.ts
@@ -32,7 +32,7 @@ class TestComponentTester extends ComponentTester<TestComponent> {
   }
 }
 
-describe('TestButton', () => {
+describe('TestSelect', () => {
   let tester: TestComponentTester;
 
   beforeEach(() => {
@@ -59,6 +59,11 @@ describe('TestButton', () => {
     expect(tester.detectChanges).toHaveBeenCalled();
   });
 
+  it('should throw if index is out of bounds', () => {
+    expect(() => tester.selectBox.selectIndex(-2)).toThrowError();
+    expect(() => tester.selectBox.selectIndex(3)).toThrowError();
+  });
+
   it('should select by value', () => {
     spyOn(tester.componentInstance, 'onChange');
     spyOn(tester, 'detectChanges').and.callThrough();
@@ -69,6 +74,10 @@ describe('TestButton', () => {
     expect(tester.detectChanges).toHaveBeenCalled();
   });
 
+  it('should throw if value does not exist', () => {
+    expect(() => tester.selectBox.selectValue('oops')).toThrowError();
+  });
+
   it('should select by label', () => {
     spyOn(tester.componentInstance, 'onChange');
     spyOn(tester, 'detectChanges').and.callThrough();
@@ -77,6 +86,10 @@ describe('TestButton', () => {
     expect(tester.selectBox.selectedIndex).toBe(1);
     expect(tester.componentInstance.onChange).toHaveBeenCalled();
     expect(tester.detectChanges).toHaveBeenCalled();
+  });
+
+  it('should throw if label does not exist', () => {
+    expect(() => tester.selectBox.selectLabel('oops')).toThrowError();
   });
 
   it('should expose the selected value', () => {

--- a/projects/ngx-speculoos/src/lib/test-select.ts
+++ b/projects/ngx-speculoos/src/lib/test-select.ts
@@ -11,34 +11,40 @@ export class TestSelect extends TestHtmlElement<HTMLSelectElement> {
   }
 
   /**
-   * Selects the option at the given index, then dispatches an event of type change and triggers a change detection
+   * Selects the option at the given index, then dispatches an event of type change and triggers a change detection.
+   * If the index is out of bounds and is not -1, then throws an error.
    */
   selectIndex(index: number): void {
+    if (index < -1 || index >= this.nativeElement.options.length) {
+      throw new Error(`The index ${index} is out of bounds`);
+    }
     this.nativeElement.selectedIndex = index;
     this.dispatchEventOfType('change');
   }
 
   /**
    * Selects the first option with the given value, then dispatches an event of type change and triggers a change detection.
-   * If there is no option with the given value, then does nothing
-   * TODO should it throw instead?
+   * If there is no option with the given value, then throws an error.
    */
   selectValue(value: string): void {
     const index = this.optionValues.indexOf(value);
     if (index >= 0) {
       this.selectIndex(index);
+    } else {
+      throw new Error(`The value ${value} is not part of the option values (${this.optionValues.join(', ')}`);
     }
   }
 
   /**
    * Selects the first option with the given label (or text), then dispatches an event of type change and triggers a change detection.
-   * If there is no option with the given label, then does nothing
-   * TODO should it throw instead?
+   * If there is no option with the given label, then throws an error.
    */
   selectLabel(label: string): void {
     const index = this.optionLabels.indexOf(label);
     if (index >= 0) {
       this.selectIndex(index);
+    } else {
+      throw new Error(`The label ${label} is not part of the option labels (${this.optionLabels.join(', ')}`);
     }
   }
 


### PR DESCRIPTION
BREAKING CHANGE:
`TestSelect`'s `selectIndex`, `selectValue` and `selectLabel` methods now throw if an invalid index, value or label is passed, instead of ignoring it.