### PR TITLE
feat: use automatic mode if zoneless change detection is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ how to write Angular unit tests.
   - [Mocking helper](#mocking-helper)
   - [Testing with a host component](#testing-with-a-host-component)
 - [Gotchas](#gotchas)
-  - [When do I need to call detectChanges()](#when-do-i-need-to-call-detectchanges)
+  - [When do I need to call detectChanges()](#when-do-i-need-to-call-change-or-detectchanges)
   - [Can I use the TestElement methods to act on the component element itself, rather than a sub-element?](#can-i-use-the-testelement-methods-to-act-on-the-component-element-itself-rather-than-a-sub-element)
 - [Issues, questions](#issues-questions)
 - [Complete example](#complete-example)
@@ -175,20 +175,21 @@ an instance of your component tester.
 ```typescript
 describe('My component', () => {
   let tester: MyComponentTester;
-  
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [MyComponent],
       ...
     });
-    
+
     tester = new MyComponentTester();
     tester.change();
   });
-  
+
   it('should ...', () => {
-    
+
   });
+});
 ```
 
 ### Automatic change detection
@@ -201,11 +202,13 @@ properly handle its state changes.
 
 This can be done by:
 
-- adding a provider in the testing module to configure the fixtures to be in _automatic_ mode
+- adding a provider in the testing module to configure the fixtures to be in _automatic_ mode,
+  or to use zoneless change detection
 - awaiting the component fixture stability when the test *thinks* that a change detection should
   automatically happen.
 
-When the `provideAutomaticChangeDetection()` provider is added, the `ComponentTester` will run in
+When the `provideAutomaticChangeDetection()` or the `provideExperimentalZonelessChangeDetection()` 
+provider is added, the `ComponentTester` will run in
 _automatic_ mode. In this mode, calling `detectChanges()` throws an error, because you should always
 let Angular decide if change detection is necessary.
 
@@ -232,8 +235,8 @@ describe('AppComponent', () => {
   beforeEach(async () => {
     TestBed.configureTestingModule({
       providers: [
-        provideComponentFixtureAutoDetection(),
-        provideExperimentalZonelessChangeDetection() // if you already uses zoneless also add this provider
+        provideComponentFixtureAutoDetection()
+        // or provideExperimentalZonelessChangeDetection() if you already use zoneless
       ]
     });
 
@@ -371,7 +374,7 @@ get birthDate() {
 ```
 
 ```typescript
-it('should not save if birth date is in the future', () =>) {
+it('should not save if birth date is in the future', () => {
   // ...
   tester.birthDate.setDate(2200, 1, 1);
   tester.save.click();
@@ -382,7 +385,7 @@ it('should not save if birth date is in the future', () =>) {
 or, in _automatic_ mode
 
 ```typescript
-it('should not save if birth date is in the future'), async () => {
+it('should not save if birth date is in the future', async () => {
   // ...
   await tester.birthDate.setDate(2200, 1, 1);
   await tester.save.click();

--- a/projects/ngx-speculoos/src/lib/component-tester.spec.ts
+++ b/projects/ngx-speculoos/src/lib/component-tester.spec.ts
@@ -1,12 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ComponentTester } from './component-tester';
-import { Component } from '@angular/core';
+import { Component, provideExperimentalZonelessChangeDetection } from '@angular/core';
 import { TestElement } from './test-element';
 import { TestInput } from './test-input';
 import { TestButton } from './test-button';
 import { TestSelect } from './test-select';
 import { TestTextArea } from './test-textarea';
 import { TestHtmlElement } from './test-html-element';
+import { provideAutomaticChangeDetection } from './providers';
 
 @Component({
   template: `
@@ -27,7 +28,7 @@ describe('ComponentTester', () => {
 
   describe('creation', () => {
     it('should create via constructor with a component type', () => {
-      const tester = new ComponentTester<TestComponent>(TestComponent);
+      const tester = new ComponentTester(TestComponent);
       expect(tester.fixture instanceof ComponentFixture).toBe(true);
       expect(tester.fixture.componentInstance instanceof TestComponent).toBe(true);
     });
@@ -42,6 +43,30 @@ describe('ComponentTester', () => {
       const tester = ComponentTester.create(TestComponent);
       expect(tester.fixture instanceof ComponentFixture).toBe(true);
       expect(tester.fixture.componentInstance instanceof TestComponent).toBe(true);
+    });
+  });
+
+  describe('mode', () => {
+    it('should be in imperative mode by default', () => {
+      TestBed.configureTestingModule({});
+      const tester = new ComponentTester(TestComponent);
+      expect(tester.mode).toBe('imperative');
+    });
+
+    it('should be in automatic mode if automatic change detection is provided', () => {
+      TestBed.configureTestingModule({
+        providers: [provideAutomaticChangeDetection()]
+      });
+      const tester = new ComponentTester(TestComponent);
+      expect(tester.mode).toBe('automatic');
+    });
+
+    it('should be in automatic mode if zoneless change detection is provided', () => {
+      TestBed.configureTestingModule({
+        providers: [provideExperimentalZonelessChangeDetection()]
+      });
+      const tester = new ComponentTester(TestComponent);
+      expect(tester.mode).toBe('automatic');
     });
   });
 

--- a/projects/ngx-speculoos/src/lib/component-tester.ts
+++ b/projects/ngx-speculoos/src/lib/component-tester.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ComponentFixture, ComponentFixtureAutoDetect, TestBed } from '@angular/core/testing';
-import { DebugElement, ProviderToken, Type } from '@angular/core';
+import { DebugElement, NgZone, ProviderToken, Type } from '@angular/core';
 import { TestTextArea } from './test-textarea';
 import { TestElement } from './test-element';
 import { TestInput } from './test-input';
@@ -53,8 +53,9 @@ export class ComponentTester<C> {
   constructor(arg: Type<C> | ComponentFixture<C>) {
     this.fixture = arg instanceof ComponentFixture ? arg : TestBed.createComponent(arg);
     const autoDetect = TestBed.inject(ComponentFixtureAutoDetect, false);
+    const zoneless = !(TestBed.inject(NgZone) instanceof NgZone);
     this.testElement = TestElementQuerier.wrap(this.debugElement, this) as TestElement<HTMLElement>;
-    this.mode = autoDetect ? 'automatic' : 'imperative';
+    this.mode = autoDetect || zoneless ? 'automatic' : 'imperative';
   }
 
   /**


### PR DESCRIPTION
The component tester is now in "automatic" mode if the `provideExperimentalZonelessChangeDetection` provider is added to the providers of the testing module, without having to additionally add the `provideAutomaticChangeDetection()` provider.